### PR TITLE
MNT: Update for conda-build 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
   sha256: 981f40b08efdf5fc91cf7f879e067459052a115462a18b01e06653eeec3da9b7
 
 build:
+  merge_build_host: True  # [win]
   noarch: generic
   number: 1000
   rpaths:
@@ -22,7 +23,7 @@ build:
     - lib/
 
 requirements:
-  build:
+  host:
     - r-base
     - r-mass
     - r-elasticnet


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've updated the recipe for conda-build 3 as instructed in #3.

List of changes done to the recipe:
Renamed build with host
Adding merge_build_host: True  # [win]


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.
